### PR TITLE
CI/CD GitHub action for toolkit modules build procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,3 +296,19 @@ kfp component build . --component-filepattern catalogue/fairbench/modelcard.py -
 
 :warning: The build should be called from a directory where both your
 module and virtual environment are subdirectories.
+
+
+## Automatic build toolkit modules
+
+You can use the **Toolkit Modules Build** action from the Actions section in github.
+
+:warning: As this procedure is very heavy on build resources please use it only when it is really needed.
+
+Before running the procedure, update the docker image version of all modules to the new one.
+
+After the procedure is completed the module_yamls file is available that can be downloaded and use the yamls in it to update your local toolkit installation.
+
+Folder named data yamls should be put in components_yaml folder of toolkit.
+
+Folder named meta yamls should be put in components_metadata folder of toolkit.
+

--- a/components_script.sh
+++ b/components_script.sh
@@ -4,31 +4,55 @@ pip install --upgrade -r requirements\[test\].txt
 pip install -e .
 
 kfp component build . --component-filepattern catalogue/dataset_loaders/auto_csv.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/custom_csv.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/data_csv_rankings.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/graph_from_csv.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/graph.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/image_pairs.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/images.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/dataset_loaders/uci_csv.py
+docker system prune -a --force --volumes
 
 kfp component build . --component-filepattern catalogue/model_loaders/compute_rankings.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/compute_researcher_ranking.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/fair_node_ranking.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/no_model.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/onnx_ensemble.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/onnx.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/model_loaders/pytorch.py
+docker system prune -a --force --volumes
 
 kfp component build . --component-filepattern catalogue/metrics/image_bias_analysis.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/interactive_report.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/interactive_sklearn_report.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/ma_graph_connection.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/model_card.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/Multi_objective_report.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/ranking_fairness.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/xai_analysis_embeddings.py
+docker system prune -a --force --volumes
 kfp component build . --component-filepattern catalogue/metrics/xai_analysis.py
+docker system prune -a --force --volumes
 
 mkdir yamls
 mkdir yamls/data

--- a/requirements[test].txt
+++ b/requirements[test].txt
@@ -21,3 +21,4 @@ seaborn
 coverage
 ucimlrepo
 plotly
+docker


### PR DESCRIPTION
GitHub action for toolkit modules build CI/CD procedure.

A new action is available for building the toolkit modules. As it is heavy on resources it is made to run manually only when needed.

The build script after each module build clears docker cache otherwise the hd space is depleted on the runner and the procedure could not be completed.