### PR TITLE
Improve docstrings for Fairlearn visualization modules

### DIFF
--- a/mai_bias/catalogue/metrics/viz_fairness_plots.py
+++ b/mai_bias/catalogue/metrics/viz_fairness_plots.py
@@ -24,9 +24,27 @@ def viz_fairness_plots(
     sensitive: List[str],
 ) -> HTML:
     """
-    <p>This module generates a detailed fairness plots using <a href="https://fairlearn.org/" target="_blank">Fairlearn</a>,
-    providing both group-wise and scalar fairness metrics across sensitive attributes such as sex or race.</p>
+    <p>
+    This module visualizes fairness metrics using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library and interactive Plotly charts. 
+    It provides visual insights into how a model performs across different groups defined by sensitive features such as gender, race, or age.
+    </p>
+    <p>
+        The module produces two sets of visual outputs:
+    </p>
+    <ul>
+        <li><strong>Group-wise metrics</strong>: Shown as grouped bar charts, these display performance metrics (e.g., false positive rate) across subgroups.</li>
+        <li><strong>Scalar metrics</strong>: Displayed as horizontal bar charts, these summarize disparities (e.g., equal opportunity difference) in a compact, interpretable format.</li>
+    </ul>
+    <p>
+        Interactive charts allow users to hover for precise values, compare metrics between groups, and quickly identify fairness gaps. 
+        An explanation panel is included to define each metric and guide interpretation.
+    </p>
+    <p>
+        This module is well suited for exploratory analysis, presentations, and fairness monitoring.
+        It makes group disparities visible and intuitive, helping identify where further scrutiny or mitigation may be needed.
+    </p>
     """
+
     # Import the existing function from mmm-fair
     from mmm_fair.fairlearn_report import generate_reports_from_fairlearn
 

--- a/mai_bias/catalogue/metrics/viz_fairness_plots.py
+++ b/mai_bias/catalogue/metrics/viz_fairness_plots.py
@@ -25,7 +25,7 @@ def viz_fairness_plots(
 ) -> HTML:
     """
     <p>
-    This module visualizes fairness metrics using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library and interactive Plotly charts. 
+    This module visualizes fairness metrics using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library and interactive Plotly charts.
     It provides visual insights into how a model performs across different groups defined by sensitive features such as gender, race, or age.
     </p>
     <p>
@@ -36,7 +36,7 @@ def viz_fairness_plots(
         <li><strong>Scalar metrics</strong>: Displayed as horizontal bar charts, these summarize disparities (e.g., equal opportunity difference) in a compact, interpretable format.</li>
     </ul>
     <p>
-        Interactive charts allow users to hover for precise values, compare metrics between groups, and quickly identify fairness gaps. 
+        Interactive charts allow users to hover for precise values, compare metrics between groups, and quickly identify fairness gaps.
         An explanation panel is included to define each metric and guide interpretation.
     </p>
     <p>

--- a/mai_bias/catalogue/metrics/viz_fairness_report.py
+++ b/mai_bias/catalogue/metrics/viz_fairness_report.py
@@ -24,9 +24,27 @@ def viz_fairness_report(
     sensitive: List[str],
 ) -> HTML:
     """
-    <p>This module generates a detailed fairness report using <a href="https://fairlearn.org/" target="_blank">Fairlearn</a>,
-    providing both group-wise and scalar fairness metrics across sensitive attributes such as sex or race.</p>
+    <p>
+        This module generates a structured fairness report using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library. 
+        It assesses whether a machine learning model behaves similarly across different population groups, as defined by sensitive attributes such as gender, race, or age.
+    </p>
+    <p>
+        The report includes two types of fairness metrics:
+    </p>
+    <ul>
+        <li><strong>Group-wise metrics</strong>: These show how the model performs for each group separately (e.g., true positive rates for Group A vs. Group B).</li>
+        <li><strong>Scalar metrics</strong>: These summarize disparities across groups into single numeric values. Small differences and ratios close to 1 indicate balanced treatment.</li>
+    </ul>
+    <p>
+        Results are presented in aligned tables with clear formatting, allowing users to compare outcomes across groups at a glance. 
+        Each metric is briefly explained to help interpret whether the model exhibits performance or outcome disparities for different groups.
+    </p>
+    <p>
+        This module is particularly useful in evaluation pipelines, audit reports, and model reviews where transparency and fairness are essential.
+        It helps teams assess group-level equity in model behavior using interpretable, tabular summaries.
+    </p>
     """
+
     # Import the existing function from mmm-fair
     from mmm_fair.fairlearn_report import generate_reports_from_fairlearn
 

--- a/mai_bias/catalogue/metrics/viz_fairness_report.py
+++ b/mai_bias/catalogue/metrics/viz_fairness_report.py
@@ -25,7 +25,7 @@ def viz_fairness_report(
 ) -> HTML:
     """
     <p>
-        This module generates a structured fairness report using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library. 
+        This module generates a structured fairness report using the <a href="https://fairlearn.org/" target="_blank">Fairlearn</a> library.
         It assesses whether a machine learning model behaves similarly across different population groups, as defined by sensitive attributes such as gender, race, or age.
     </p>
     <p>
@@ -36,7 +36,7 @@ def viz_fairness_report(
         <li><strong>Scalar metrics</strong>: These summarize disparities across groups into single numeric values. Small differences and ratios close to 1 indicate balanced treatment.</li>
     </ul>
     <p>
-        Results are presented in aligned tables with clear formatting, allowing users to compare outcomes across groups at a glance. 
+        Results are presented in aligned tables with clear formatting, allowing users to compare outcomes across groups at a glance.
         Each metric is briefly explained to help interpret whether the model exhibits performance or outcome disparities for different groups.
     </p>
     <p>


### PR DESCRIPTION
This PR improves the docstrings for the two recently merged Fairlearn-based modules (viz_fairness_report, viz_fairness_plots) to align with the documentation requirements. Descriptions are now in HTML format and tailored to a general technical audience.