### PR TITLE
handling http image loading

### DIFF
--- a/data/xai_images/torch_transform.py
+++ b/data/xai_images/torch_transform.py
@@ -1,12 +1,40 @@
+from io import BytesIO
+import requests
 import torchvision.transforms as transforms
 from PIL import Image as PILImage
+import urllib.parse
 
+def img_loader(img_path, base_url=""):
+    """
+    If img_path is already a URL or not a string, it returns img_path as is.
 
-def img_loader(img_path):
+    Note: This function also includes logic to *load* the image from the
+    generated URL using the 'requests' library, as PIL cannot directly
+    open images from HTTP URLs.
+    """
+    # url examples: "http://localhost:5500", "http://minio-service:9000/"
+
     if not isinstance(img_path, str):
         return img_path
-    image = PILImage.open(img_path).convert("RGB")
-    return image
+    elif base_url == "":
+        image = PILImage.open(img_path).convert("RGB")
+        return image
+    else: 
+        full_url = urllib.parse.urljoin(base_url, img_path)
+
+
+        print(full_url)
+        try:
+            # Fetch the image content from the URL
+            # Use stream=True and iter_content for large files if needed
+            response = requests.get(full_url)
+            response.raise_for_status() # Raise an exception for HTTP errors (4xx or 5xx)
+
+            # Open the image using PIL from the fetched content
+            image = PILImage.open(BytesIO(response.content)).convert("RGB")
+            return image
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Failed to load image from URL '{full_url}': {e}") from e
 
 
 transform = transforms.Compose(

--- a/data/xai_images/torch_transform.py
+++ b/data/xai_images/torch_transform.py
@@ -22,8 +22,6 @@ def img_loader(img_path, base_url=""):
     else: 
         full_url = urllib.parse.urljoin(base_url, img_path)
 
-
-        print(full_url)
         try:
             # Fetch the image content from the URL
             # Use stream=True and iter_content for large files if needed

--- a/data/xai_images/torch_transform_fv.py
+++ b/data/xai_images/torch_transform_fv.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+import requests
 import torchvision.transforms as transforms
 from PIL import Image as PILImage
 
@@ -11,12 +13,34 @@ def to_bgr(img):
     else:
         raise ValueError(f"Unexpected image shape: {img.shape}")
 
+def img_loader(img_path, url_str=""):
+    """
+    If img_path is already a URL or not a string, it returns img_path as is.
 
-def img_loader(img_path):
+    Note: This function also includes logic to *load* the image from the
+    generated URL using the 'requests' library, as PIL cannot directly
+    open images from HTTP URLs.
+    """
+    # minio_url = f"http://localhost:9000/{img_path}"
+
     if not isinstance(img_path, str):
         return img_path
-    image = PILImage.open(img_path).convert("RGB")
-    return image
+    elif url_str == "":
+        image = PILImage.open(img_path).convert("RGB")
+        return image
+    else: 
+        full_url = f"{url_str}/{img_path}"
+        try:
+            # Fetch the image content from the URL
+            # Use stream=True and iter_content for large files if needed
+            response = requests.get(full_url)
+            response.raise_for_status() # Raise an exception for HTTP errors (4xx or 5xx)
+
+            # Open the image using PIL from the fetched content
+            image = PILImage.open(BytesIO(response.content)).convert("RGB")
+            return image
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Failed to load image from URL '{full_url}': {e}") from e
 
 
 # Important note: make sure that your transforms have resize and normalize!

--- a/mai_bias/catalogue/dataset_loaders/image_pairs.py
+++ b/mai_bias/catalogue/dataset_loaders/image_pairs.py
@@ -18,7 +18,7 @@ def data_image_pairs(
     data_transform_path: str = "",
     transform_variable: str = "transform",
     num_workers: int = 0,
-    safe_libraries="numpy,torch,torchvision,PIL",
+    safe_libraries="numpy,torch,torchvision,PIL,io,requests,urllib",
 ) -> ImagePairs:
     """
     Loads image pairs declared in a CSV file.

--- a/mai_bias/catalogue/dataset_loaders/images.py
+++ b/mai_bias/catalogue/dataset_loaders/images.py
@@ -18,7 +18,7 @@ def data_images(
     data_transform_path: str = "",
     transform_variable: str = "transform",
     num_workers: int = 0,
-    safe_libraries="numpy,torch,torchvision,PIL",
+    safe_libraries="numpy,torch,torchvision,PIL,io,requests,urllib",
 ) -> Image:
     """
     Loads image data from a CSV file holding their sensitive and predictive attribute


### PR DESCRIPTION
Added the functionality for loading images using url format. The implementation is in the transforms.py file, allowing users to opt for their domain. If the user does not provide the "base_url" arg, the images are loaded using the local relative path (ie, as before). 